### PR TITLE
fix openmp build and reformat with isort&black

### DIFF
--- a/monotonic_align/setup.py
+++ b/monotonic_align/setup.py
@@ -1,9 +1,45 @@
-from distutils.core import setup
+import os
+import platform
+from distutils.core import Extension, setup
+
+import numpy as np
 from Cython.Build import cythonize
-import numpy
+
+# make openmp available
+system = platform.system()
+if system == "Windows":
+    extra_compile_args = []
+    extra_link_args = ["/openmp"]
+elif system == "Linux":
+    extra_compile_args = ["-fopenmp"]
+    extra_link_args = ["-fopenmp"]
+elif system == "Darwin":
+    os.system("brew install libomp")
+    extra_compile_args = ["-Xpreprocessor", "-fopenmp"]
+    extra_link_args = ["-L/usr/local/lib", "-lomp"]
+else:
+    extra_compile_args = ["-fopenmp"]
+    extra_link_args = ["-fopenmp"]
+
+ext_modules = [
+    Extension(
+        name="monotonic_align.core",
+        sources=["core.pyx"],
+        include_dirs=[np.get_include()],
+        extra_compile_args=extra_compile_args,
+        extra_link_args=extra_link_args,
+    )
+]
 
 setup(
-  name = 'monotonic_align',
-  ext_modules = cythonize("core.pyx"),
-  include_dirs=[numpy.get_include()]
+    name="monotonic_align",
+    ext_modules=cythonize(
+        ext_modules,
+        compiler_directives={
+            "cdivision": True,
+            "embedsignature": True,
+            "boundscheck": False,
+            "wraparound": False,
+        },
+    ),
 )


### PR DESCRIPTION
- With proper configuration of openmp, cython's prange can benefit from multi core CPU, other wise it will fallback to a single thread loop, see [cython's document](https://docs.cython.org/en/stable/src/userguide/parallelism.html#compiling)
- Reformat with isort and black which follows PEP8