### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ ko_pron
 indic_transliteration
 num_thai
 opencc
+audonnx


### PR DESCRIPTION
`numpy` 版本过低，造成 `torch` 无法正常运行
![1](https://user-images.githubusercontent.com/65452214/212177084-a1e0c61f-0147-438f-a37b-3ea88a070bc4.png)
同时由于 `numba` 需要 `numpy` 版本低于 1.24
![2](https://user-images.githubusercontent.com/65452214/212177576-24433154-464b-4f27-8bd1-f1b87fb29b6c.png)
因此能使用的最高版本就是1.23.5，该版本下，`torch` 能正常运行

在 [MoeGoe.py 的 176 行](https://github.com/CjangCjengh/MoeGoe/blob/master/MoeGoe.py#L176) 引入了 `audonnx`，安装 requirements.txt 的时候没安装到，运行到此处会报错