### PR TITLE
fix: Single speaker model occurs error

### DIFF
--- a/models.py
+++ b/models.py
@@ -363,7 +363,7 @@ class SynthesizerTrn(nn.Module):
     else:
       self.dp = DurationPredictor(hidden_channels, 256, 3, 0.5, gin_channels=gin_channels)
 
-    if n_speakers > 1:
+    if n_speakers >= 1:
       self.emb_g = nn.Embedding(n_speakers, gin_channels)
 
   def infer(self, x, x_lengths, sid=None, noise_scale=1, length_scale=1, noise_scale_w=1., max_len=None, emotion_embedding=None):


### PR DESCRIPTION
Hi! Thank you for your project!
I found an error while using it with single speaker model. When n_speakers = 1, it occurs error: `AttributeError: 'SynthesizerTrn' object has no attribute 'emb_g'`
I modified `if n_speakers > 1:` to `if n_speakers >= 1:` then it works.